### PR TITLE
feat/FFENT-9879- Add WKND sample MOGRT guide and navigation

### DIFF
--- a/src/pages/config.md
+++ b/src/pages/config.md
@@ -43,3 +43,4 @@
     - [Using the Describe API](/guides/dgr/dgr-describe.md)
     - [Using the Render API](/guides/dgr/dgr-render.md)
     - [Best practices for Dynamic Graphics Render and MOGRTs](/guides/dgr/dgr-best-practices.md)
+    - [Sample MOGRT Project](/guides/dgr/dgr-sample-mogrt-wknd.md)

--- a/src/pages/guides/dgr/dgr-best-practices.md
+++ b/src/pages/guides/dgr/dgr-best-practices.md
@@ -472,6 +472,7 @@ We support [predefined social presets](index.md#sample-request) or a custom pres
 
 ## See also
 
+- [WKND Product Showcase sample MOGRT package](dgr-sample-mogrt-wknd.md)
 - [Using the Presets API](index.md)
 - [Using the Describe API](dgr-describe.md)
 - [Using the Render API](dgr-render.md)

--- a/src/pages/guides/dgr/dgr-sample-mogrt-wknd.md
+++ b/src/pages/guides/dgr/dgr-sample-mogrt-wknd.md
@@ -1,0 +1,59 @@
+---
+title: Showcase MOGRT project package
+description: A MOGRT project example for Dynamic Graphics Render—Beginner and Advanced templates, assets, CSV/JSON samples, fonts, and PDF docs.
+keywords:
+  - Dynamic Graphics Render
+  - DGR
+  - MOGRT
+  - WKND
+  - sample
+  - Motion Graphics Templates
+  - After Effects
+contributors:
+  - https://github.com/aeabreu-hub
+  - https://github.com/sandeepy-gh
+  - https://github.com/schhatwalgitacc
+---
+
+# Showcase MOGRT project package
+
+Use the **Product Showcase sample package** to learn how Motion Graphics Templates (MOGRTs) work with the Firefly Services **Dynamic Graphics Render (DGR)** API. The package includes two template tiers, test media, tabular sample data, required fonts, and hand-off documentation.
+
+## Get the package
+
+The sample files are maintained in the **[ffs-mogrt-package](https://github.com/AEAbreu-hub/ffs-mogrt-package)** GitHub repository. Clone the repository or download the contents as your workflow allows.
+
+<InlineAlert variant="info" slots="heading, text" />
+
+Repository access
+
+The repository README describes how to obtain the full file set.
+
+## Purpose of the hand-off documentation
+
+The package includes **DGR Sample Demo MOGRT – Documentation** (PDF in the `Documentation/` folder). It is written as a hand-off from a **motion designer** to an **automation technologist** (the integrator). It explains which assets and values the DGR API expects so you can map CSV or application data to Describe and Render requests.
+
+## Beginner and advanced MOGRTs
+
+Two MOGRT files are provided:
+
+| Tier | Use |
+| --- | --- |
+| **Beginner** | A smaller set of customizable properties that reflects the standard range supported by DGR. |
+| **Advanced** | A larger set of customizable properties for deeper variation. |
+
+Files:
+
+- `DGR-Demo-MOGRT_WKND-Product-Showcase_Beginner.mogrt`
+- `DGR-Demo-MOGRT_WKND-Product-Showcase_Advanced.mogrt`
+
+Properties called out for **Advanced only** in the PDF (highlighted rows in the source document) apply only when you use the Advanced MOGRT.
+
+## See also
+
+- [Authentication and setup](../../getting-started/index.md)
+- [Best practices for Dynamic Graphics Render and MOGRTs](dgr-best-practices.md)
+- [Using the Presets API](index.md)
+- [Using the Describe API](dgr-describe.md)
+- [Using the Render API](dgr-render.md)
+- [Technical usage notes](../../getting-started/usage/index.md)

--- a/src/pages/guides/dgr/index.md
+++ b/src/pages/guides/dgr/index.md
@@ -25,6 +25,8 @@ Presets are export configurations that define video quality. They control parame
 
 Retrieve a catalog of predefined, social-first presets to discover the available encoding options for rendering outputs. Developers can use the presets in the guide below, or their own custom ones.
 
+For a full sample MOGRT project (WKND Product Showcase) with Beginner and Advanced templates, media, and documentation, see [WKND Product Showcase sample MOGRT package](dgr-sample-mogrt-wknd.md).
+
 ## Prerequisites
 
 [Review the Getting Started page](../../getting-started/index.md) for this API for authentication and setup.


### PR DESCRIPTION
# Summary

Adds a Dynamic Graphics Render guide page for the WKND Product Showcase sample MOGRT package (GitHub-hosted), registers it in the sidenav, and links from the Presets quickstart and best-practices guides.

# Changes

## `src/pages/guides/dgr/dgr-sample-mogrt-wknd.md`
* New guide: sample package source repo, Beginner vs Advanced MOGRTs, bundled assets and documentation, fonts, Describe/Render workflow, and See also links.

## `src/pages/config.md`
* Add sidenav entry: Sample MOGRT (WKND Product Showcase).

## `src/pages/guides/dgr/index.md`
* Add overview pointer to the new sample package page from the Presets API quickstart.

## `src/pages/guides/dgr/dgr-best-practices.md`
* Add See also link to the WKND sample MOGRT package page.

# Context

## Jira
[FFENT-9879](https://jira.corp.adobe.com/browse/FFENT-9879)


Made with [Cursor](https://cursor.com)