### PR TITLE
Increase render variations limit to 500

### DIFF
--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -88,7 +88,7 @@ The API workflow is simple and powerful. It mirrors other video API's asynchrono
    These are Essential Graphics parameters defined in MOGRT.
 
 3. **Render template variations** with defined assets and presets.  
-   Render up to 10 variations of the same template in a single call.
+   Render up to 500 variations of the same template in a single call.
 
 4. **Get Status** with a job ID to get results of Describe and Render template API calls.
 


### PR DESCRIPTION
Updated the maximum number of variations that can be rendered from 10 to 500.

## Description

The Dynamic Graphics Render API (DGR) documentation on the Adobe Audio/Video Firefly Services overview page incorrectly states that a single render call supports a maximum of 10 template variations. The API has since been updated to support up to 500 variations per call, but the documentation has not been updated to reflect this change.

## Related Issue

https://jira.corp.adobe.com/browse/FFSS-694

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
