### PR TITLE
[Reframe] Add bundled OTIO sidecar delivery docs and fix Semantic Subject Lock link

### DIFF
--- a/src/pages/guides/reframe/index.md
+++ b/src/pages/guides/reframe/index.md
@@ -186,6 +186,30 @@ When this option is enabled, you can download a **.zip archive** containing:
 
 When `applyLetterboxing` is set to `true`, the output may contain letterboxing for vertical formats and pillarboxing for horizontal aspect ratios.
 
+* By default, when requesting an `otio` sidecar (`output.format.sidecar: "otio"`) with multiple renditions, each rendition receives its own sidecar file. To instead receive **one combined sidecar bundle** for all renditions, set `output.sidecarOptions`:
+
+```json
+"output": {
+    "format": {
+        "sidecar": "otio"
+    },
+    "sidecarOptions": {
+        "delivery": "bundled",
+        "bundleDestination": {
+            "url": "<pre-signed_PUT_URL_to_upload_the_combined_sidecar_bundle>"
+        }
+    }
+}
+```
+
+`sidecarOptions.delivery` accepts:
+
+* **`per_rendition`** (default): each rendition receives its own sidecar file — this is the current behavior described above.
+* **`bundled`**: all renditions' sidecar data is bundled into a single archive. The upload location you provide in `bundleDestination` is echoed back as `sidecarBundleDestination` in the job status response.
+* **`bundled_no_source`**: same as `bundled`, but the source footage is excluded from the archive.
+
+This option is currently only supported when `output.format.sidecar` is `"otio"` — using it with any other sidecar type returns a validation error. `bundleDestination` is only valid when `delivery` is `bundled` or `bundled_no_source`, and cannot be combined with a per-rendition `sidecarDestination`.
+
 For full details, [see the API Reference](../../api/index.md).
 
 ## Add video overlays
@@ -427,5 +451,24 @@ A successful response when the processing job is complete contains a secure link
         }
       }
     ]
+}
+```
+
+If the request set `output.sidecarOptions.delivery` to `"bundled"` or `"bundled_no_source"`, the response includes a job-level `sidecarBundleDestination` instead of a per-rendition `sidecarDestination`:
+
+```json
+{
+    "jobId": "<job_ID>",
+    "status": "succeeded",
+    "outputs": [
+      {
+        "mediaDestination": {
+          "url": "<pre-signed_PUT_URL_to_upload_the_output_video_to_user_bucket>"
+        }
+      }
+    ],
+    "sidecarBundleDestination": {
+      "url": "<pre-signed_PUT_URL_to_upload_the_combined_sidecar_bundle>"
+    }
 }
 ```

--- a/static/openapi/audio-video-api.json
+++ b/static/openapi/audio-video-api.json
@@ -2443,6 +2443,37 @@
                             }
                           ]
                         }
+                      },
+                      "layout": {
+                        "type": "object",
+                        "properties": {
+                          "applyLetterboxing": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "When set to true, applies letterboxing (for vertical output formats) or pillarboxing (for horizontal output formats) instead of cropping to preserve the full source frame."
+                          }
+                        },
+                        "description": "Layout configuration for the output."
+                      },
+                      "sidecarOptions": {
+                        "type": "object",
+                        "properties": {
+                          "delivery": {
+                            "type": "string",
+                            "enum": [
+                              "per_rendition",
+                              "bundled",
+                              "bundled_no_source"
+                            ],
+                            "default": "per_rendition",
+                            "description": "Controls how sidecar files are delivered. `per_rendition` (default) delivers a separate sidecar file for each rendition (current behavior). `bundled` combines all renditions' sidecar data into a single archive, whose location is returned as `sidecarBundleDestination` in the job status response. `bundled_no_source` behaves like `bundled` but excludes the source footage from the archive. Currently only applicable when `output.format.sidecar` is `otio`; using it with any other sidecar type returns a validation error."
+                          },
+                          "bundleDestination": {
+                            "$ref": "#/components/schemas/Destination",
+                            "description": "Job-level upload target for the combined sidecar bundle. Only applicable when `delivery` is `bundled` or `bundled_no_source`. Cannot be used when any rendition specifies its own `sidecarDestination`."
+                          }
+                        },
+                        "description": "Optional configuration controlling how sidecar files across renditions are delivered."
                       }
                     },
                     "required": [
@@ -2547,6 +2578,49 @@
                       ],
                       "layout": {
                         "applyLetterboxing": false
+                      }
+                    }
+                  }
+                },
+                "BundledSidecarExample": {
+                  "summary": "Example requesting a single bundled OTIO sidecar archive for all renditions",
+                  "value": {
+                    "video": {
+                      "source": {
+                        "url": "<pre-signed_URL_to_download_the_video_input>"
+                      }
+                    },
+                    "analysis": {
+                      "sceneEditDetection": true,
+                      "focalPoints": []
+                    },
+                    "output": {
+                      "format": {
+                        "media": "mp4",
+                        "sidecar": "otio"
+                      },
+                      "renditions": [
+                        {
+                          "aspectRatio": {
+                            "x": 1,
+                            "y": 1
+                          },
+                          "mediaDestination": {
+                            "url": "<pre-signed_put_URL_to_upload_the_output_video_to_user_bucket>"
+                          }
+                        },
+                        {
+                          "aspectRatio": {
+                            "x": 16,
+                            "y": 9
+                          }
+                        }
+                      ],
+                      "sidecarOptions": {
+                        "delivery": "bundled",
+                        "bundleDestination": {
+                          "url": "<presigned_upload_URL_for_combined_OTIO_bundle>"
+                        }
                       }
                     }
                   }
@@ -2965,6 +3039,10 @@
                               }
                             ]
                           }
+                        },
+                        "sidecarBundleDestination": {
+                          "$ref": "#/components/schemas/Destination",
+                          "description": "Location of the combined sidecar bundle. Present only when the request's `output.sidecarOptions.delivery` was `bundled` or `bundled_no_source`."
                         }
                       },
                       "required": [
@@ -3052,6 +3130,10 @@
                             ]
                           },
                           "description": "Details of the job's partial success, including successful outputs and any errors encountered."
+                        },
+                        "sidecarBundleDestination": {
+                          "$ref": "#/components/schemas/Destination",
+                          "description": "Location of the combined sidecar bundle. Present only when the request's `output.sidecarOptions.delivery` was `bundled` or `bundled_no_source`."
                         }
                       },
                       "required": [
@@ -5744,7 +5826,7 @@
             "default": [],
             "externalDocs": {
               "description": "See documentation for Semantic Subject Lock.",
-              "url": "https://developer.adobe.com/reframev2/getting-started/semantic-search/"
+              "url": "https://developer.adobe.com/audio-video-firefly-services/getting-started/semantic-search/"
             }
           }
         },


### PR DESCRIPTION
## Description

Adds documentation for a new **bundled OTIO sidecar delivery** option and fixes an incorrect external link.

- Adds `output.sidecarOptions` (`delivery`: `per_rendition` | `bundled` | `bundled_no_source`, and `bundleDestination`) to the OpenAPI spec, with a new `BundledSidecarExample` request example and a `sidecarBundleDestination` field on the job status response schema.
- Adds the corresponding `layout.applyLetterboxing` schema definition to the OpenAPI spec (previously documented only in prose, missing from the spec itself).
- Updates the Reframe guide (`src/pages/guides/reframe/index.md`) with request/response examples for the new bundled sidecar option.
- Fixes the Semantic Subject Lock external doc link, which pointed at `developer.adobe.com/reframev2/...` instead of `developer.adobe.com/audio-video-firefly-services/...`.

## Related Issue

FFENT-14826

## Motivation and Context

Documents a new API capability (combining multiple renditions' OTIO sidecar files into a single bundle) so developers can discover and use it, and corrects a broken reference link in the API reference docs.

## How Has This Been Tested?

Validated that `static/openapi/audio-video-api.json` is valid JSON and conforms to the OpenAPI schema.

## Screenshots (if appropriate):

N/A — documentation/spec changes only.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
